### PR TITLE
Add Pagination to Admin Review Art Page

### DIFF
--- a/src/api/API.js
+++ b/src/api/API.js
@@ -6,15 +6,33 @@ const API_URL = import.meta.env.VITE_API_URL;
 console.log("🔍 API URL:", API_URL); // ✅ Debugging Step
 
 // ✅ Function to fetch all images
-export async function getAllImages(token) {
+export async function getAllImages(token, page=1, limit=50, stage) {
   try {
+    // set up pagination query
+    const params = { page, limit, stage };
+
     const response = await axios.get(`${API_URL}/api/admin/all_images`, {
       headers: { Authorization: `Bearer ${token}` },
+      params,
     });
 
-    return response.data.images || [];
+    return response.data;
   } catch (error) {
     console.error("Error fetching images:", error.response?.data || error);
+    return [];
+  }
+}
+
+// ✅ Function to load statistics of all images
+export async function getAllImagesStats(token) {
+  try {
+    const response = await axios.get(`${API_URL}/api/admin/all_images/stats`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    return response.data;
+  }
+  catch (error) {
+    console.error("Error fetching images stats:", error.response?.data || error);
     return [];
   }
 }

--- a/src/components/ArtDetails.jsx
+++ b/src/components/ArtDetails.jsx
@@ -9,7 +9,6 @@ function ArtDetails() {
     const navigate = useNavigate();
     const [art, setArt] = useState(null);
     const [loading, setLoading] = useState(true);
-    const email = localStorage.getItem("userEmail") || "admin@example.com";
 
     useEffect(() => {
         const fetchArt = async () => {

--- a/src/components/Pagination.jsx
+++ b/src/components/Pagination.jsx
@@ -1,0 +1,99 @@
+import '@styles/pagination.css';
+
+export function Pagination({ totalPages, page, onChange }) {
+    const pageNumbers = Array.from({ length: totalPages }, (_, i) => i + 1);
+
+    // display a set of page numbers
+    const getPageNumbersToDisplay = () => {
+        let pagesToDisplay = [];
+        const displaySize = (window.innerWidth <= 480) ? 2 : 5;
+
+        // return what it is within 5 pages
+        if(totalPages <= displaySize){
+            pagesToDisplay = pageNumbers;
+        }
+        else{
+            const lastPage = pageNumbers[pageNumbers.length - 1];
+
+            // display by page set: fist set (page 1 to displaySize), middle set, last set(n-5 to n)
+            if(page <= displaySize){
+                pagesToDisplay = [...pageNumbers.slice(0, displaySize), '...', lastPage];
+            }
+            else if(page > displaySize && page <= totalPages - displaySize){
+                const start = page - 2
+                const end = page + 2;
+
+                pagesToDisplay = [
+                    ...pageNumbers.slice(start-1, end), 
+                    '...', 
+                    lastPage
+                ];
+            }
+            else{
+                pagesToDisplay = [...pageNumbers.slice(totalPages-displaySize, totalPages)];
+            }
+        }
+
+        return pagesToDisplay;
+    };
+
+    const pagesToDisplay = getPageNumbersToDisplay();
+
+    return (
+        <div className='paginationContainer'>
+            {/* render buttons to prev & first page */}
+            <button
+                className={`page caret`} 
+                onClick={() => onChange(1)}
+                disabled={page == 1}
+            >
+                &#171;
+            </button>
+
+            <button
+                className={`page caret`} 
+                onClick={() => onChange(page-1)}
+                disabled={page == 1}
+            >
+                &#8249;
+            </button>
+
+            {/* render all / 5 page numbers at a time */}
+            {
+                pagesToDisplay.map((pageNum, index) => {
+                    const buttonType = (pageNum === page) ? "curr" : "";
+                    if(pageNum === '...'){
+                        return <span key={index}>...</span>;
+                    }
+
+                    return (
+                        <button
+                            key={index} 
+                            className={`page ${buttonType}`} 
+                            onClick={() => onChange(pageNum)}
+                        >
+                            {pageNum}
+                        </button>
+                    );
+                })
+            }
+
+            {/* render buttons to next & last page */}
+            <button
+                className={`page caret`} 
+                onClick={() => onChange(page+1)}
+                disabled={page == totalPages}
+            >
+                &#8250;
+            </button>
+
+            <button
+                className={`page caret`} 
+                onClick={() => onChange(totalPages)}
+                disabled={page == totalPages}
+            >
+                &#187;
+            </button>
+        </div>
+    );  
+}

--- a/src/components/TopPanel.jsx
+++ b/src/components/TopPanel.jsx
@@ -1,19 +1,49 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useAuth } from "../context/authContext";
+import { getAllImagesStats } from "../api/API";
+
 import StatsList from "./StatsList";
 import "@styles/toppanel.css"; // ✅ Import the CSS file
 
 function TopPanel({ 
-  totalImages, 
-  totalPending, 
-  totalApproved, 
-  totalRejected, 
   onShowAllArt,  // ✅ New function prop
   onFilterPending, 
   onFilterApproved, 
   onFilterRejected, 
   onSearch, 
   viewMode, 
-  toggleViewMode
+  toggleViewMode,
+  pageSize,
+  handlePageSizeChange,
 }) {
+  // 
+  const { authState } = useAuth();
+  const navigate = useNavigate();
+  
+  const [totalImages, setTotalImages] = useState(0);
+  const [totalPending, setTotalPending] = useState(0);
+  const [totalApproved, setTotalApproved] = useState(0);
+  const [totalRejected, setTotalRejected] = useState(0);
+
+  useEffect(() => {
+    const loadStats = async () => {
+      if (!authState || !authState.token) {
+        console.error("No token found, redirecting to login.");
+        navigate("/login");
+        return;
+      }
+
+      const response = await getAllImagesStats(authState.token);
+      setTotalImages(response.stats.total);
+      setTotalPending(response.stats.pending);
+      setTotalApproved(response.stats.approved);
+      setTotalRejected(response.stats.rejected);
+    };
+
+    loadStats();
+  }, [authState?.token])
+
   // render 4 types of stats for arts
   const stats = [
     { label: "Total Pictures", value: totalImages, filter: onShowAllArt },
@@ -37,6 +67,18 @@ function TopPanel({
         <button className="viewToggleButton" onClick={toggleViewMode}>
           {viewMode === "grid" ? "📋 List" : "🖼️ Grid"}
         </button>
+
+        <div className="selectPageSize">
+          <label>Images per page: </label>
+          <select 
+            value={pageSize}
+            onChange={handlePageSizeChange}
+          >
+            <option value={10}>10</option>
+            <option value={25}>25</option>
+            <option value={50}>50</option>
+          </select>
+        </div>
       </div>
     </div>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -13,6 +13,8 @@
   -moz-osx-font-smoothing: grayscale;
 
   /* define color var */
+  --primary-color: #007bff;
+  --secondary-color: #0056b3;
   --font-color: #213547;
   --hover-color: #747bff;
   --button-bg-color: #f9f9f9;

--- a/src/styles/artdetails.css
+++ b/src/styles/artdetails.css
@@ -113,7 +113,7 @@
     left: 20px;
     padding: 5px 12px;
     font-size: 10px;
-    background-color: #007bff;
+    background-color: var(--primary-color);
     color: white;
     border-radius: 0px;
     cursor: pointer;

--- a/src/styles/listview.css
+++ b/src/styles/listview.css
@@ -66,7 +66,7 @@ th, td {
 }
 
 .sortable:hover {
-    color: #007bff;
+    color: var(--primary-color);
 }
 
 .profile-image {

--- a/src/styles/login.css
+++ b/src/styles/login.css
@@ -88,7 +88,7 @@
 
 .input-group input:focus {
   outline: none;
-  border-color: #007bff;
+  border-color: var(--primary-color);
   box-shadow: 0 0 5px rgba(0, 123, 255, 0.3);
   background: #fff;
 }
@@ -100,9 +100,9 @@
 button {
   width: 100%;
   padding: 12px 15px;
-  background-color: #007bff;
+  background-color: var(--primary-color);
   color: white;
-  border: 1px solid #007bff;
+  border: 1px solid var(--primary-color);
   border-radius: 8px;
   font-size: 16px;
   font-weight: 500;

--- a/src/styles/pagination.css
+++ b/src/styles/pagination.css
@@ -1,0 +1,54 @@
+.paginationContainer{
+    width: 70%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 15px;
+}
+
+.page {
+    height: 50px;
+    width: 50px;
+    border: none;
+    background-color: transparent;
+    color: var(--font-color);
+    border-radius: 100%;
+
+    &:hover{
+        box-shadow: none;
+        border-color: none;
+        background-color: #e7e7e7;
+        transform: translateY(-2px);
+    }
+}
+
+.page.curr{
+    color: white;
+    border-radius: 100%;
+    background-color: var(--primary-color);
+
+    &:hover{
+        background-color: var(--secondary-color);
+    }
+}
+
+.page.caret{
+    font-size: large;
+}
+
+.page.caret:disabled{
+    color: rgb(185, 185, 185);
+
+    &:hover{
+        transform: none;
+        background-color: transparent;
+    }
+}
+
+/* display smaller pagination on phone */
+@media (max-width: 480px) {
+    .page {
+        height: 40px;
+        width: 40px;
+    }
+}

--- a/src/styles/reviewart.css
+++ b/src/styles/reviewart.css
@@ -10,6 +10,7 @@
 
     padding: 20px;
     margin: 0 auto; /* ✅ Centers the container */
+    gap: 20px;
 }
 
 /* Grid layout for displaying artworks */

--- a/src/styles/toppanel.css
+++ b/src/styles/toppanel.css
@@ -27,7 +27,7 @@
 .search-view-container {
     display: flex;
     align-items: center;
-    gap: 10px;
+    gap: 15px;
 }
 
 /* ✅ Styles the search bar */
@@ -44,7 +44,7 @@
 .viewToggleButton {
     padding: 6px 8px;
     font-size: 12px;
-    background-color: #007bff;
+    background-color: var(--primary-color);
     color: white;
     border: none;
     border-radius: 5px;
@@ -63,8 +63,12 @@
 }
 
 .clickable:hover {
-    color: #007bff;
+    color: var(--primary-color);
     text-decoration: underline;
+}
+
+.selectPageSize{
+    min-width: 150px;
 }
 
 /* display panel vertically (1 row stats, 1 row search bar) on phone */

--- a/src/styles/userdetails.css
+++ b/src/styles/userdetails.css
@@ -69,7 +69,7 @@
     align-self: flex-start;
     margin-bottom: 10px;
     padding: 8px 12px;
-    background-color: #007bff;
+    background-color: var(--primary-color);
     color: white;
     border: none;
     cursor: pointer;

--- a/vite.config.js
+++ b/vite.config.js
@@ -14,6 +14,6 @@ export default defineConfig({
   server: {
     host: '0.0.0.0',
     strictPort: true,
-    port: 5137,
+    port: 5173,
   }
 })


### PR DESCRIPTION
- Updated port number in `vite.config.js`:
> 1. Changed the port from 5137 to 5173 (i think it was a typo?) since backend cors url expected `localhost:5173` by default

- Added pagination to Admin Review Art Page:
> 1. Users can view images with a page size of 10, 25, or 50 images per page
> 2. Users can view images fetched at different pages
> 3. Users can filter by stage and view result in pagination (will recall API to re-fetch)
> 4. Users can search in pagination (doesn't call API but only search in current page)