### PR TITLE
Show sold badge on art cards in admin review panel

### DIFF
--- a/src/components/ArtCard.jsx
+++ b/src/components/ArtCard.jsx
@@ -34,8 +34,10 @@ function ArtCard({ art }) {
               <h3 className="art-card-title">{art.name}</h3>
               <p className="art-card-artist">{art.artistName}</p>
             </div>
-            {/* ✅ Status badge aligned with text */}
-            <div className="art-stage-container">{getStageLabel()}</div>
+            <div className="art-stage-container">
+              {art.isSold && <span className="art-stage sold">Sold</span>}
+              {getStageLabel()}
+            </div>
           </div>
           
           {/* ✅ Show Reviewer Info if Available */}

--- a/src/styles/artcard.css
+++ b/src/styles/artcard.css
@@ -84,6 +84,10 @@
 /* ─── Status badge ─── */
 .art-stage-container {
   flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 3px;
 }
 
 .art-stage {
@@ -113,6 +117,12 @@
   background: #fffbeb;
   color: #b45309;
   border-color: #fde68a;
+}
+
+.art-stage.sold {
+  background: #0f172a;
+  color: #fff;
+  border-color: #0f172a;
 }
 
 /* ─── Reviewer ─── */


### PR DESCRIPTION
Admin ArtCard now shows a black SOLD badge above the stage badge when soldStatus is sold, so admins can see sold artworks at a glance without clicking into each one.


Claude-Session: https://claude.ai/code/session_01QK3pHMoW7QKDnr4DGNXcDe